### PR TITLE
Remove runtime dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Keep your lambdas warm during Winter.
 
 **Requirements:**
 * Serverless *v1.12.x* or higher.
-* AWS provider and nodejs4.3 or nodejs6.10 runtimes
+* AWS provider
 
 ## How it works
 

--- a/src/index.js
+++ b/src/index.js
@@ -31,13 +31,8 @@ class WarmUP {
     this.options = options
     this.custom = this.serverless.service.custom
 
-    /** Runtime >=node4.3 */
-    const validRunTime = (!this.serverless.service.provider.runtime ||
-      this.serverless.service.provider.runtime === 'nodejs4.3' ||
-      this.serverless.service.provider.runtime === 'nodejs6.10')
-
     /** AWS provider and valid runtime check */
-    if (this.serverless.service.provider.name === 'aws' && validRunTime) {
+    if (this.serverless.service.provider.name === 'aws') {
       /** Serverless hooks */
       this.hooks = {
         'after:deploy:initialize': this.afterDeployInitialize.bind(this),
@@ -243,6 +238,7 @@ class WarmUP {
       handler: this.pathHandler,
       memorySize: this.warmup.memorySize,
       name: this.warmup.name,
+      runtime: 'nodejs6.10',
       package: {
         exclude: ['**'],
         include: [this.folderName + '/**']

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ class WarmUP {
     this.options = options
     this.custom = this.serverless.service.custom
 
-    /** AWS provider and valid runtime check */
+    /** AWS provider check */
     if (this.serverless.service.provider.name === 'aws') {
       /** Serverless hooks */
       this.hooks = {


### PR DESCRIPTION
I couldn't see a reason for this plugin to only work with nodejs runtimes, I've used it successfully with Python after a minor adjustment so that the warmup function runtime is overridden to nodejs6.1 rather than the providers default runtime.

Python early exit code I'm using is
```
# Immediate response for WarmUP plugin
if event.get('source', None) == 'serverless-plugin-warmup':
    print('WarmUP - Lambda is warm!')
    return 'Lambda is warm!'
```

Invoking the event
> START RequestId: ... Version: $LATEST
2017-05-06T10:55:40.488Z    ...    Warm Up Start
2017-05-06T10:55:40.751Z    ...    Warm Up Invoke Success: x-y-z { StatusCode: 200, Payload: '"Lambda is warm!"' }
2017-05-06T10:55:40.751Z    ...    Warm Up Finished with 0 invoke errors
END RequestId: ...
REPORT RequestId: ...  Duration: 329.97 ms Billed Duration: 400 ms     Memory Size: 128 MB Max Memory Used: 34 MB  

