### PR TITLE
docs(readme): Add Gotchas section and info about deploying to VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ custom:
 }
 ```
 
+## Gotchas
+
+If you are deploying to a VPC, you need to use private subnets with a Network Address Translation (NAT) gateway (http://docs.aws.amazon.com/lambda/latest/dg/vpc.html). WarmUp requires this so it can call the other lambdas but this is applicable to any lambda that needs access to the public internet or to any other AWS service.
+
 ## Cost
 
 Lambda pricing [here](https://aws.amazon.com/lambda/pricing/). CloudWatch pricing [here](https://aws.amazon.com/cloudwatch/pricing/). You can use [AWS Lambda Pricing Calculator](https://s3.amazonaws.com/lambda-tools/pricing-calculator.html) to check how much will cost you monthly.


### PR DESCRIPTION
Related to https://github.com/FidelLimited/serverless-plugin-warmup/issues/13

The issue was the way I was deploying the lambda in the VPC.
I've added a Gotcha section to the Readme so no one else has to spend half a day investigating this.