### PR TITLE
fix(config): Moves config to the constructor so it's generated not on…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,10 +38,12 @@ class WarmUP {
       'after:package:createDeploymentArtifacts': this.afterCreateDeploymentArtifacts.bind(this),
       'after:deploy:deploy': this.afterDeployFunctions.bind(this)
     }
+
+    this.configPlugin()
   }
 
   /**
-   * @description After package initialize hook
+   * @description After package initialize hook. Create warmer function and add it to the service.
    *
    * @fulfil {} — Warm up set
    * @reject {Error} Warm up error
@@ -49,14 +51,11 @@ class WarmUP {
    * @return {(boolean|Promise)}
    * */
   afterPackageInitialize () {
-    this.configPlugin()
-
-    /** Create warmer function and add it to the service */
     return this.createWarmer()
   }
 
   /**
-   * @description After create deployment artifacts
+   * @description After create deployment artifacts. Clean prefix folder.
    *
    * @fulfil {} — Optimization finished
    * @reject {Error} Optimization error
@@ -64,7 +63,6 @@ class WarmUP {
    * @return {Promise}
    * */
   afterCreateDeploymentArtifacts () {
-    /** Clean prefix folder */
     return this.cleanFolder()
   }
 


### PR DESCRIPTION
…ly for packaging but also for deployment. Closes FidelLimited/serverless-plugin-warmup/20

I'm currently travelling so I'm not able to test this thoroughly but based on the issue raised at https://github.com/FidelLimited/serverless-plugin-warmup/issues/20, the problem is that the config is only generated only on the pre-packaging phase. It should be always generated.

I will look deeper into this when I have some time (in a couple weeks) to see if the `his.serverless.service.custom` property is preserved even when running deploy on a packaged folder. But for now, I think that this should solve the problem.