### PR TITLE
Include all option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ plugins:
 
 * Add a `warmup` property to all functions you want to be warm.
 
+
 You can enable WarmUp in general:
 
 ```yml
@@ -56,6 +57,15 @@ functions:
       - production
       - staging
 ```
+Do not warm-up a lambda if includeAll (see below) is turned on:
+
+```yml
+functions:
+  hello:
+    warmup:
+      exclude: true
+```
+
 * WarmUP to be able to `invoke` lambdas requires the following Policy Statement in `iamRoleStatements`:
 
 ```yaml
@@ -98,6 +108,7 @@ module.exports.lambdaToWarm = function(event, context, callback) {
 * **timeout** (default `10` seconds)
 * **prewarm** (default `false`)
 * **folderName** (default `_warmup`)
+* **includeAll** (default `false`) - can also be an array of stages
 
 ```yml
 custom:
@@ -109,12 +120,14 @@ custom:
     timeout: 20
     prewarm: true // Run WarmUp immediately after a deployment
     folderName: '_warmup' // Name of the folder created for the generated warmup lambda
+    includeAll: false
 ```
 
 **Options should be tweaked depending on:**
 * Number of lambdas to warm up
 * Day cold periods
 * Desire to avoid cold lambdas after a deployment
+* Desire to warm-up all lambdas by default
 
 **Lambdas invoked by WarmUP will have event source `serverless-plugin-warmup`:**
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ Do not warm-up a lambda if `includeAll` (see below) is turned on:
 ```yml
 functions:
   hello:
-    warmup:
-      exclude: true
+    warmup: false
 ```
 
 * WarmUP to be able to `invoke` lambdas requires the following Policy Statement in `iamRoleStatements`:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ functions:
       - production
       - staging
 ```
-Do not warm-up a lambda if includeAll (see below) is turned on:
+Do not warm-up a lambda if `includeAll` (see below) is turned on:
 
 ```yml
 functions:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ plugins:
 
 * Add a `warmup` property to all functions you want to be warm.
 
-
 You can enable WarmUp in general:
 
 ```yml

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ class WarmUP {
    * @param {!Object} serverless - Serverless object
    * @param {!Object} options - Serverless options
    * */
-  constructor (serverless, options) {
+  constructor(serverless, options) {
     /** Serverless variables */
     this.serverless = serverless
     this.options = options
@@ -47,7 +47,7 @@ class WarmUP {
    *
    * @return {(boolean|Promise)}
    * */
-  afterPackageInitialize () {
+  afterPackageInitialize() {
     this.configPlugin()
     return this.createWarmer()
   }
@@ -60,7 +60,7 @@ class WarmUP {
    *
    * @return {Promise}
    * */
-  afterCreateDeploymentArtifacts () {
+  afterCreateDeploymentArtifacts() {
     return this.cleanFolder()
   }
 
@@ -72,7 +72,7 @@ class WarmUP {
    *
    * @return {Promise}
    * */
-  afterDeployFunctions () {
+  afterDeployFunctions() {
     this.configPlugin()
     if (this.warmup.prewarm) {
       return this.warmUpFunctions()
@@ -84,7 +84,7 @@ class WarmUP {
    *
    * @return {}
    * */
-  configPlugin () {
+  configPlugin() {
     /** Set warm up folder, file and handler paths */
     this.folderName = '_warmup'
     if (this.custom && this.custom.warmup && typeof this.custom.warmup.folderName === 'string') {
@@ -101,7 +101,8 @@ class WarmUP {
       name: this.serverless.service.service + '-' + this.options.stage + '-warmup-plugin',
       schedule: ['rate(5 minutes)'],
       timeout: 10,
-      prewarm: false
+      prewarm: false,
+      includeAll: false
     }
 
     /** Set global custom options */
@@ -140,6 +141,11 @@ class WarmUP {
     if (typeof this.custom.warmup.prewarm === 'boolean') {
       this.warmup.prewarm = this.custom.warmup.prewarm
     }
+
+    /** Include all by default */
+    if (typeof this.custom.warmup.includeAll === 'boolean' || Array.isArray(this.custom.warmup.includeAll)) {
+      this.warmup.includeAll = this.custom.warmup.includeAll
+    }
   }
 
   /**
@@ -149,7 +155,7 @@ class WarmUP {
    *
    * @return {String} Absolute file path
    * */
-  getPath (file) {
+  getPath(file) {
     return path.join(this.serverless.config.servicePath, file)
   }
 
@@ -161,7 +167,7 @@ class WarmUP {
    *
    * @return {Promise}
    * */
-  cleanFolder () {
+  cleanFolder() {
     if (!this.warmup.cleanFolder) {
       return Promise.resolve()
     }
@@ -176,7 +182,7 @@ class WarmUP {
    *
    * @return {Promise}
    * */
-  createWarmer () {
+  createWarmer() {
     /** Get functions */
     const allFunctions = this.serverless.service.getAllFunctions()
 
@@ -185,10 +191,14 @@ class WarmUP {
       const functionObject = this.serverless.service.getFunction(functionName)
 
       /** Function needs to be warm */
-      if (functionObject.warmup === true ||
+      if ((functionObject.warmup === true ||
         functionObject.warmup === this.options.stage ||
         (Array.isArray(functionObject.warmup) &&
-          functionObject.warmup.indexOf(this.options.stage) !== -1)) {
+          functionObject.warmup.indexOf(this.options.stage) !== -1)) ||
+        (this.options.includeAll === true ||
+          (Array.isArray(this.options.includeAll) &&
+            this.options.includeAll.indexOf(this.options.stage) !== -1) &&
+          functionObject.exclude !== true) {
         return functionObject
       }
     }).then((functionNames) => {
@@ -219,7 +229,7 @@ class WarmUP {
    *
    * @return {Promise}
    * */
-  createWarmUpFunctionArtifact (functionNames) {
+  createWarmUpFunctionArtifact(functionNames) {
     /** Log warmup start */
     this.serverless.cli.log('WarmUP: setting ' + functionNames.length + ' lambdas to be warm')
 
@@ -272,7 +282,7 @@ module.exports.warmUp = (event, context, callback) => {
    *
    * @return {Object} Warm up service function object
    * */
-  addWarmUpFunctionToService () {
+  addWarmUpFunctionToService() {
     /** SLS warm up function */
     this.serverless.service.functions.warmUpPlugin = {
       description: 'Serverless WarmUP Plugin',
@@ -301,7 +311,7 @@ module.exports.warmUp = (event, context, callback) => {
    *
    * @return {Promise}
    * */
-  warmUpFunctions () {
+  warmUpFunctions() {
     this.serverless.cli.log('WarmUP: Pre-warming up your functions')
 
     const params = {

--- a/src/index.js
+++ b/src/index.js
@@ -190,15 +190,16 @@ class WarmUP {
     return BbPromise.filter(allFunctions, (functionName) => {
       const functionObject = this.serverless.service.getFunction(functionName)
 
-      /** Function needs to be warm */
-      if ((functionObject.warmup === true ||
+      const explicitlyIncluded = functionObject.warmup === true ||
         functionObject.warmup === this.options.stage ||
         (Array.isArray(functionObject.warmup) &&
-          functionObject.warmup.indexOf(this.options.stage) !== -1)) ||
-        (this.options.includeAll === true ||
-          (Array.isArray(this.options.includeAll) &&
-            this.options.includeAll.indexOf(this.options.stage) !== -1) &&
-          functionObject.exclude !== true) {
+          functionObject.warmup.indexOf(this.options.stage) !== -1)
+      const implicitlyIncluded = (this.warmup.includeAll === true ||
+        (Array.isArray(this.warmup.includeAll) &&
+          this.warmup.includeAll.indexOf(this.options.stage) !== -1)) &&
+        !(functionObject.warmup === false)
+      /** Function needs to be warm */
+      if (explicitlyIncluded || implicitlyIncluded) {
         return functionObject
       }
     }).then((functionNames) => {

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ class WarmUP {
    * @param {!Object} serverless - Serverless object
    * @param {!Object} options - Serverless options
    * */
-  constructor(serverless, options) {
+  constructor (serverless, options) {
     /** Serverless variables */
     this.serverless = serverless
     this.options = options
@@ -47,7 +47,7 @@ class WarmUP {
    *
    * @return {(boolean|Promise)}
    * */
-  afterPackageInitialize() {
+  afterPackageInitialize () {
     this.configPlugin()
     return this.createWarmer()
   }
@@ -60,7 +60,7 @@ class WarmUP {
    *
    * @return {Promise}
    * */
-  afterCreateDeploymentArtifacts() {
+  afterCreateDeploymentArtifacts () {
     return this.cleanFolder()
   }
 
@@ -72,7 +72,7 @@ class WarmUP {
    *
    * @return {Promise}
    * */
-  afterDeployFunctions() {
+  afterDeployFunctions () {
     this.configPlugin()
     if (this.warmup.prewarm) {
       return this.warmUpFunctions()
@@ -84,7 +84,7 @@ class WarmUP {
    *
    * @return {}
    * */
-  configPlugin() {
+  configPlugin () {
     /** Set warm up folder, file and handler paths */
     this.folderName = '_warmup'
     if (this.custom && this.custom.warmup && typeof this.custom.warmup.folderName === 'string') {
@@ -155,7 +155,7 @@ class WarmUP {
    *
    * @return {String} Absolute file path
    * */
-  getPath(file) {
+  getPath (file) {
     return path.join(this.serverless.config.servicePath, file)
   }
 
@@ -167,7 +167,7 @@ class WarmUP {
    *
    * @return {Promise}
    * */
-  cleanFolder() {
+  cleanFolder () {
     if (!this.warmup.cleanFolder) {
       return Promise.resolve()
     }
@@ -182,7 +182,7 @@ class WarmUP {
    *
    * @return {Promise}
    * */
-  createWarmer() {
+  createWarmer () {
     /** Get functions */
     const allFunctions = this.serverless.service.getAllFunctions()
 
@@ -230,7 +230,7 @@ class WarmUP {
    *
    * @return {Promise}
    * */
-  createWarmUpFunctionArtifact(functionNames) {
+  createWarmUpFunctionArtifact (functionNames) {
     /** Log warmup start */
     this.serverless.cli.log('WarmUP: setting ' + functionNames.length + ' lambdas to be warm')
 
@@ -283,7 +283,7 @@ module.exports.warmUp = (event, context, callback) => {
    *
    * @return {Object} Warm up service function object
    * */
-  addWarmUpFunctionToService() {
+  addWarmUpFunctionToService () {
     /** SLS warm up function */
     this.serverless.service.functions.warmUpPlugin = {
       description: 'Serverless WarmUP Plugin',
@@ -312,7 +312,7 @@ module.exports.warmUp = (event, context, callback) => {
    *
    * @return {Promise}
    * */
-  warmUpFunctions() {
+  warmUpFunctions () {
     this.serverless.cli.log('WarmUP: Pre-warming up your functions')
 
     const params = {


### PR DESCRIPTION
Hey, great plugin! Thanks for creating it.

I have quite a large project where I need most of my lambdas kept warm, so in the interests of DRY I thought it would be handy to add an option that allows all lambdas to default to being warmed-up with `warmup: false` being used to exclude specific ones.

cheers
Steve