### PR TITLE
Move stage and region resolution to after init

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,16 +30,6 @@ class WarmUP {
     this.serverless = serverless
     this.options = options
 
-    // See https://github.com/serverless/serverless/issues/2631
-    this.options.stage  = this.options.stage
-      || this.serverless.service.provider.stage
-      || (this.serverless.service.defaults && this.serverless.service.defaults.stage)
-      || 'dev'
-    this.options.region = this.options.region
-      || this.serverless.service.provider.region
-      || (this.serverless.service.defaults && this.serverless.service.defaults.region)
-      || 'us-east-1'
-
     this.custom = this.serverless.service.custom
     this.provider = this.serverless.getProvider('aws')
 
@@ -59,6 +49,16 @@ class WarmUP {
    * @return {(boolean|Promise)}
    * */
   afterPackageInitialize () {
+    // See https://github.com/serverless/serverless/issues/2631
+    this.options.stage  = this.options.stage
+      || this.serverless.service.provider.stage
+      || (this.serverless.service.defaults && this.serverless.service.defaults.stage)
+      || 'dev'
+    this.options.region = this.options.region
+      || this.serverless.service.provider.region
+      || (this.serverless.service.defaults && this.serverless.service.defaults.region)
+      || 'us-east-1'
+      
     this.configPlugin()
     return this.createWarmer()
   }


### PR DESCRIPTION
If the stage / region values need to be resolved (file reference, etc.), they should be accessed after the package has been fully populated (not pre-populated, see Serverless Variables class).