### PR TITLE
Move custom config resolution to after init

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,6 @@ class WarmUP {
     this.serverless = serverless
     this.options = options
 
-    this.custom = this.serverless.service.custom
     this.provider = this.serverless.getProvider('aws')
 
     this.hooks = {
@@ -58,7 +57,8 @@ class WarmUP {
       || this.serverless.service.provider.region
       || (this.serverless.service.defaults && this.serverless.service.defaults.region)
       || 'us-east-1'
-      
+    this.custom = this.serverless.service.custom
+    
     this.configPlugin()
     return this.createWarmer()
   }


### PR DESCRIPTION
If the custom configuration needs to be resolved, e.g. by file reference, it is not available until the package has been populated (see Serveless Variables).