### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,13 @@
+language: node_js
+node_js:
+  - "6"
+  - "7"
+  - "8"
+  - "9"
+  - "10"
+script:
+  - "npm run lint"
+#   - "npm run test-with-coverage"
+# after_success:
+#   - "npm run coveralls"
+sudo: false


### PR DESCRIPTION
Let's at least enable Travis to enforce correct linting.

In the next commit, once the build works, I'll add the badge to the Readme.