### PR TITLE
allow customization of event source (fixes #26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ if(context.custom.source === 'serverless-plugin-warmup'){
 * **schedule** (default `rate(5 minutes)`) - More examples [here](https://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html).
 * **timeout** (default `10` seconds)
 * **prewarm** (default `false`)
+* **source** (default `{ "source": "serverless-plugin-warmup" }`)
+* **sourceRaw** (default `false`)
 * **tags** (default to serverless default tags)
 
 ```yml
@@ -244,6 +246,8 @@ custom:
     schedule: 'cron(0/5 8-17 ? * MON-FRI *)' // Run WarmUP every 5 minutes Mon-Fri between 8:00am and 5:55pm (UTC)
     timeout: 20
     prewarm: true // Run WarmUp immediately after a deploymentlambda
+    source: '{ "source": "my-custom-payload" }'
+    sourceRaw: true // Won't JSON.stringify() the source, may be necessary for Go/AppSync deployments
     tags:
       Project: foo
       Owner: bar    
@@ -254,7 +258,7 @@ custom:
 * Day cold periods
 * Desire to avoid cold lambdas after a deployment
 
-**Lambdas invoked by WarmUP will have event source `serverless-plugin-warmup`:**
+**Lambdas invoked by WarmUP will have event source `serverless-plugin-warmup` (unless otherwise specified above):**
 
 ```json
 {

--- a/src/index.js
+++ b/src/index.js
@@ -113,6 +113,7 @@ class WarmUP {
       name: this.serverless.service.service + '-' + this.options.stage + '-warmup-plugin',
       schedule: ['rate(5 minutes)'],
       timeout: 10,
+      source: JSON.stringify({ source: 'serverless-plugin-warmup' }),
       prewarm: false
     }
 
@@ -161,6 +162,11 @@ class WarmUP {
     /** Timeout */
     if (typeof this.custom.warmup.timeout === 'number') {
       this.warmup.timeout = this.custom.warmup.timeout
+    }
+
+    /** Source */
+    if (typeof this.custom.warmup.source !== 'undefined') {
+      this.warmup.source = this.custom.warmup.sourceRaw ? this.custom.warmup.source : JSON.stringify(this.custom.warmup.source)
     }
 
     /** Pre-warm */
@@ -275,7 +281,7 @@ module.exports.warmUp = async (event, context, callback) => {
       InvocationType: "RequestResponse",
       LogType: "None",
       Qualifier: process.env.SERVERLESS_ALIAS || "$LATEST",
-      Payload: '${JSON.stringify({ source: 'serverless-plugin-warmup' })}'
+      Payload: '${this.warmup.source}'
     };
 
     try {
@@ -345,7 +351,7 @@ module.exports.warmUp = async (event, context, callback) => {
       InvocationType: 'RequestResponse',
       LogType: 'None',
       Qualifier: process.env.SERVERLESS_ALIAS || '$LATEST',
-      Payload: JSON.stringify({ source: 'serverless-plugin-warmup' })
+      Payload: this.warmup.source
     }
 
     return this.provider.request('Lambda', 'invoke', params)


### PR DESCRIPTION
Adds optional `source` and `sourceRaw` field to customization. `source` will default to `{ "source": "serverless-plugin-warmup" }` if not configured.