### PR TITLE
Concurrency option for warming up X instances of of a lambda.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ functions:
     warmup: false
 ```
 
+Warm-up multiple concurrent instances of your functions:
+```yml
+custom:
+  warmup:
+    concurency: 2
+```
+
+Maintain different levels of concurrency per function: 
+```yml
+custom:
+  warmup:
+    concurrency: 1
+
+...
+
+functions:
+  hello:
+    warmupConcurrency: 5 
+```
+
 * WarmUP requires some permissions to be able to `invoke` lambdas.
 
 ```yaml
@@ -208,6 +228,19 @@ You can also check for the warmp event using the `context` variable. This could 
 ...
 
 if(context.custom.source === 'serverless-plugin-warmup'){
+  console.log('WarmUP - Lambda is warm!')
+  return callback(null, 'Lambda is warm!')
+}
+
+...
+```
+If you're using the `concurrency` option you might consider adding a slight delay before returning when warming up to ensure your function doesn't return before all concurrent requests have been started:
+
+```javascript
+...
+
+if(context.custom.source === 'serverless-plugin-warmup'){
+  await sleep(25) // Pause for 25ms
   console.log('WarmUP - Lambda is warm!')
   return callback(null, 'Lambda is warm!')
 }

--- a/README.md
+++ b/README.md
@@ -237,15 +237,16 @@ if(context.custom.source === 'serverless-plugin-warmup'){
 If you're using the `concurrency` option you might consider adding a slight delay before returning when warming up to ensure your function doesn't return before all concurrent requests have been started:
 
 ```javascript
-...
+module.exports.lambdaToWarm = function(event, context, callback) {
+  /** Slightly delayed response for WarmUP plugin to ensure concurrent invocation */
+  if (event.source === 'serverless-plugin-warmup') {
+    await new Promise(r => setTimeout(r, 25))
+    console.log('WarmUP - Lambda is warm!')
+    return
+  }
 
-if(context.custom.source === 'serverless-plugin-warmup'){
-  await sleep(25) // Pause for 25ms
-  console.log('WarmUP - Lambda is warm!')
-  return callback(null, 'Lambda is warm!')
+  ... add lambda logic after
 }
-
-...
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -291,8 +291,8 @@ If you're using the `concurrency` option you might consider adding a slight dela
 
 ```javascript
 module.exports.lambdaToWarm = function(event, context, callback) {
-  /** Slightly delayed response for WarmUP plugin to ensure concurrent invocation */
   if (event.source === 'serverless-plugin-warmup') {
+    /** Slightly delayed (25ms) response for WarmUP plugin to ensure concurrent invocation */
     await new Promise(r => setTimeout(r, 25))
     console.log('WarmUP - Lambda is warm!')
     return

--- a/README.md
+++ b/README.md
@@ -110,27 +110,6 @@ functions:
       enabled: false
 ```
 
-Warm-up multiple concurrent instances of your functions:
-```yml
-custom:
-  warmup:
-    concurency: 2
-```
-
-Maintain different levels of concurrency per function: 
-```yml
-custom:
-  warmup:
-    concurrency: 1
-
-...
-
-functions:
-  hello:
-    warmupConcurrency: 5 
-```
-
-* WarmUP requires some permissions to be able to `invoke` lambdas.
 ### Other Options
 
 #### Global options
@@ -150,6 +129,7 @@ functions:
 * **enabled** (default `false`)
 * **source** (default `{ "source": "serverless-plugin-warmup" }`)
 * **sourceRaw** (default `false`)
+* **concurrency** (default `1`)
 
 ```yml
 custom:
@@ -167,7 +147,8 @@ custom:
     timeout: 20
     prewarm: true // Run WarmUp immediately after a deploymentlambda
     source: '{ "source": "my-custom-payload" }'
-    sourceRaw: true // Won't JSON.stringify() the source, may be necessary for Go/AppSync deployments   
+    sourceRaw: true // Won't JSON.stringify() the source, may be necessary for Go/AppSync deployments
+    concurrency: 5 // Warm up 5 concurrent instances
 ```
 
 **Options should be tweaked depending on:**

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ if(context.custom.source === 'serverless-plugin-warmup'){
 * **source** (default `{ "source": "serverless-plugin-warmup" }`)
 * **sourceRaw** (default `false`)
 * **tags** (default to serverless default tags)
+* **concurrency** (default `1`)
 
 ```yml
 custom:
@@ -248,6 +249,7 @@ custom:
     prewarm: true // Run WarmUp immediately after a deploymentlambda
     source: '{ "source": "my-custom-payload" }'
     sourceRaw: true // Won't JSON.stringify() the source, may be necessary for Go/AppSync deployments
+    concurrency: 2 // How many concurrent instances of a lambda to warm - can be overridden per lambda by setting warmupConcurrency in the function definition.
     tags:
       Project: foo
       Owner: bar    

--- a/src/index.js
+++ b/src/index.js
@@ -300,7 +300,7 @@ module.exports.warmUp = async (event, context, callback) => {
     
     for (let x = 0; x < concurrency; x++) {
       const params = {
-        ClientContext: Buffer.from({"custom":source, "concurrencyIndex":x}}).toString('base64')}",
+        ClientContext: Buffer.from({"custom":source, "concurrencyIndex":x}).toString('base64')}",
         FunctionName: functionName,
         InvocationType: "RequestResponse",
         LogType: "None",

--- a/src/index.js
+++ b/src/index.js
@@ -313,13 +313,15 @@ module.exports.warmUp = async (event, context, callback) => {
       promises.push(lambda.invoke(params).promise());
     }
     
-    return Promise.all(promises).then(function(data) {
+    let success = true;
+    Promise.all(promises).then(function(data) {
       console.log(\`Warm Up Invoke Success: \${functionName}\`, data);
-      resolve(true);
+      success = true;
     }, function(err) {
       console.log(\`Warm Up Invoke Error: \${functionName}\`, err);
-      resolve(false);
+      success = false;
     });
+    return success;
   }));
 
   console.log(\`Warm Up Finished with \${invokes.filter(r => !r).length} invoke errors\`);

--- a/src/index.js
+++ b/src/index.js
@@ -297,7 +297,7 @@ module.exports.warmUp = async (event, context, callback) => {
   console.log("Warm Up Start");
   const invokes = await Promise.all(functionNames.map(async (functionName) => {
     let concurrency = functionConcurrency[functionName] > 0 ? functionConcurrency[functionName] : 1;
-    let source = ${JSON.stringify(this.warmup.source)};
+    let source = ${this.warmup.source};
     let promises = [];
     
     console.log(\`Warming up function: \${functionName} with concurrency: \${concurrency}\`);
@@ -309,15 +309,15 @@ module.exports.warmUp = async (event, context, callback) => {
         InvocationType: "RequestResponse",
         LogType: "None",
         Qualifier: process.env.SERVERLESS_ALIAS || "$LATEST",
-        Payload: source
+        Payload: JSON.stringify(source)
       };
       
       console.log("Queuing lambda invocation.", params); 
-      promises.push(lambda.invoke(params));
+      promises.push(lambda.invoke(params).promise());
     }
     
     let success = true;
-    Promise.all(promises).then(function(data) {
+    await Promise.all(promises).then(function(data) {
       console.log(\`Warm Up Invoke Success: \${functionName}\`, data);
       success = true;
     }, function(err) {

--- a/src/index.js
+++ b/src/index.js
@@ -300,7 +300,7 @@ module.exports.warmUp = async (event, context, callback) => {
     
     for (let x = 0; x < concurrency; x++) {
       const params = {
-        ClientContext: Buffer.from({"custom":source, "concurrencyIndex":x}).toString('base64'),
+        ClientContext: Buffer.from(JSON.stringify({"custom":source, "concurrencyIndex":x})).toString('base64'),
         FunctionName: functionName,
         InvocationType: "RequestResponse",
         LogType: "None",

--- a/src/index.js
+++ b/src/index.js
@@ -235,9 +235,8 @@ class WarmUP {
 
       /** Function needs to be warm */
       if (enable(functionConfig)) {
-        const concurrency = functionObject.hasOwnProperty('warmup') && functionObject.warmup.hasOwnProperty('concurrency')
-          ? functionObject.warmup.concurrency
-          : this.warmup.concurrency
+        const concurrency = functionObject.hasOwnProperty('warmupConcurrency') && typeof functionObject.warmupConcurrency === 'number'
+          ? functionObject.warmupConcurrency : this.warmup.concurrency
         functionConcurrency[functionName] = concurrency
 
         return true
@@ -266,6 +265,7 @@ class WarmUP {
    * @description Write warm up ES6 function
    *
    * @param {Array} functionNames - Function names
+   * @param (Dictionary) functionConcurrency - Mapping of concurrency level by function name
    *
    * @fulfil {} — Warm up function created
    * @reject {Error} Warm up error

--- a/src/index.js
+++ b/src/index.js
@@ -313,7 +313,7 @@ module.exports.warmUp = async (event, context, callback) => {
       };
       
       console.log("Queuing lambda invocation.", params); 
-      promises.push(lambda.invoke(params).promise());
+      promises.push(lambda.invoke(params));
     }
     
     let success = true;

--- a/src/index.js
+++ b/src/index.js
@@ -295,7 +295,7 @@ module.exports.warmUp = async (event, context, callback) => {
   console.log("Warm Up Start");
   const invokes = await Promise.all(functionNames.map(async (functionName) => {
     let concurrency = functionConcurrency[functionName] > 0 ? functionConcurrency[functionName] : 1;
-    let source = "${this.warmup.source}";
+    let source = ${JSON.stringify(this.warmup.source)};
     let promises = [];
     
     for (let x = 0; x < concurrency; x++) {

--- a/src/index.js
+++ b/src/index.js
@@ -256,7 +256,6 @@ class WarmUP {
    * @description Write warm up ES6 function
    *
    * @param {Array} functionNames - Function names
-   * @param (Dictionary) functionConcurrency - Mapping of concurrency level by function name
    *
    * @fulfil {} — Warm up function created
    * @reject {Error} Warm up error
@@ -272,8 +271,7 @@ class WarmUP {
       let functionInfo = {}
       const functionObject = this.serverless.service.getFunction(functionName)
       functionInfo.name = functionObject.name
-      functionInfo.concurrency = functionObject.hasOwnProperty('warmupConcurrency') &&
-        typeof functionObject.warmupConcurrency === 'number'
+      functionInfo.concurrency = typeof functionObject.warmupConcurrency === 'number'
         ? functionObject.warmupConcurrency : this.warmup.concurrency
       this.serverless.cli.log(`WarmUP: ${functionInfo.name} concurrency: ${functionInfo.concurrency}`)
       return functionInfo

--- a/src/index.js
+++ b/src/index.js
@@ -300,7 +300,7 @@ module.exports.warmUp = async (event, context, callback) => {
     
     for (let x = 0; x < concurrency; x++) {
       const params = {
-        ClientContext: Buffer.from({"custom":source, "concurrencyIndex":x}).toString('base64')}",
+        ClientContext: Buffer.from({"custom":source, "concurrencyIndex":x}).toString('base64'),
         FunctionName: functionName,
         InvocationType: "RequestResponse",
         LogType: "None",

--- a/src/index.js
+++ b/src/index.js
@@ -277,9 +277,11 @@ class WarmUP {
     this.serverless.cli.log('WarmUP: setting ' + functionNames.length + ' lambdas to be warm')
 
     /** Get function names */
+    let fullFunctionConcurrency = {}
     functionNames = functionNames.map((functionName) => {
       const functionObject = this.serverless.service.getFunction(functionName)
       this.serverless.cli.log('WarmUP: ' + functionObject.name)
+      fullFunctionConcurrency[functionObject.name] = functionConcurrency[functionName]
       return functionObject.name
     })
 
@@ -290,7 +292,7 @@ const aws = require("aws-sdk");
 aws.config.region = "${this.options.region}";
 const lambda = new aws.Lambda();
 const functionNames = ${JSON.stringify(functionNames)};
-const functionConcurrency = ${JSON.stringify(functionConcurrency)};
+const functionConcurrency = ${JSON.stringify(fullFunctionConcurrency)};
 module.exports.warmUp = async (event, context, callback) => {
   console.log("Warm Up Start");
   const invokes = await Promise.all(functionNames.map(async (functionName) => {

--- a/src/index.js
+++ b/src/index.js
@@ -300,6 +300,8 @@ module.exports.warmUp = async (event, context, callback) => {
     let source = ${JSON.stringify(this.warmup.source)};
     let promises = [];
     
+    console.log(\`Warming up function: \${functionName}\` with concurrency: \${concurrency}\`);
+    
     for (let x = 0; x < concurrency; x++) {
       const params = {
         ClientContext: Buffer.from(JSON.stringify({"custom":source, "concurrencyIndex":x})).toString('base64'),
@@ -310,6 +312,7 @@ module.exports.warmUp = async (event, context, callback) => {
         Payload: source
       };
       
+      console.log("Queuing lambda invocation.", params); 
       promises.push(lambda.invoke(params).promise());
     }
     

--- a/src/index.js
+++ b/src/index.js
@@ -300,7 +300,7 @@ module.exports.warmUp = async (event, context, callback) => {
     let source = ${JSON.stringify(this.warmup.source)};
     let promises = [];
     
-    console.log(\`Warming up function: \${functionName}\` with concurrency: \${concurrency}\`);
+    console.log(\`Warming up function: \${functionName} with concurrency: \${concurrency}\`);
     
     for (let x = 0; x < concurrency; x++) {
       const params = {


### PR DESCRIPTION
The default concurrency value is 1 and can be set in custom.warmup.concurrency for all lambdas and can be overridden by specifying a warmupConcurrency value at the function definition level.  I'm not super knowledgeable on YAML, node or developing serverless plugins so I wasn't sure if using <function>.warmup.concurrency would work since <function>.warmup is already being used as a specific config value (true/false/stage) rather than a config section.

Also, another value is passed along with the source to both the context and payload of the call, concurrencyIndex.  That's added in case someone wants special handling for the first X concurrent instances.

I've tested that this is working and is calling my lambda functions but using the AWS SDK to invoke the lambda instead of invoking through the API gateway really isn't helping for my use case which is a public REST API that's also in a VPC.  Apparently this method of warming isn't warming everything up completely.

I thought about updating this further to check if the function uses the API gateway then call the external endpoint in order to warm it (or maybe use APIGateway.testInvokeMethod()) but I'm not sure I want to tackle that right now.