### PR TITLE
Add more tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "6"
   - "7"
   - "8"
   - "9"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "standard **/*.js",
     "lint:fix": "standard --fix **/*.js",
     "test": "jest test",
-    "test-with-coverage": "jest --coverage test",
+    "test-with-coverage": "jest --coverage --collectCoverageFrom=src/**/*.js test",
     "coveralls": "cat coverage/lcov.info | coveralls"
   },
   "author": "Gonçalo Neves",

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ class WarmUP {
       ? [{ schedule: config.schedule }]
       : (Array.isArray(config.schedule))
         ? config.schedule.map(schedule => ({ schedule }))
-        : undefined
+        : config.events
 
     return {
       folderName,

--- a/src/index.js
+++ b/src/index.js
@@ -318,7 +318,7 @@ module.exports.warmUp = async (event, context, callback) => {
     }
 
     if (this.warmupOpts.vpc) {
-      this.serverless.service.functions.vpc = this.warmupOpts.vpc
+      this.serverless.service.functions.warmUpPlugin.vpc = this.warmupOpts.vpc
     }
 
     /** Return service function object */

--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,7 @@ class WarmUP {
    *
    * @return {Object} - Global configuration options
    * */
-  getGlobalConfig (possibleConfig, defaultOpts = {}) {
+  getGlobalConfig (possibleConfig, defaultOpts) {
     const config = (typeof possibleConfig === 'object') ? possibleConfig : {}
     const folderName = (typeof config.folderName === 'string') ? config.folderName : '_warmup'
     const pathFolder = path.join(this.serverless.config.servicePath, folderName)
@@ -191,9 +191,7 @@ class WarmUP {
       concurrency: 1
     }
 
-    const customConfig = (service.custom && typeof service.custom.warmup !== 'undefined')
-      ? service.custom.warmup
-      : {}
+    const customConfig = service.custom ? service.custom.warmup : undefined
 
     return Object.assign(
       this.getGlobalConfig(customConfig, globalDefaultOpts),

--- a/test/constructor.test.js
+++ b/test/constructor.test.js
@@ -1,31 +1,7 @@
 /* global describe it expect */
 
 const WarmUP = require('../src/index')
-
-function getServerlessConfig (serverless = {}) {
-  return {
-    getProvider: serverless.getProvider || (() => {}),
-    config: {
-      servicePath: (serverless.config && serverless.config.servicePath) ? serverless.config.servicePath : 'testPath'
-    },
-    cli: console,
-    service: {
-      provider: (serverless.service && serverless.service.provider)
-        ? serverless.service.provider
-        : { stage: '', region: '' },
-      defaults: (serverless.service && serverless.service.defaults)
-        ? serverless.service.defaults
-        : { stage: '', region: '' },
-      service: 'warmup-test',
-      custom: (serverless.service && serverless.service.custom) ? serverless.service.custom : {},
-      functions: (serverless.service && serverless.service.functions) ? serverless.service.functions : {}
-    }
-  }
-}
-
-function getOptions (options = {}) {
-  return options
-}
+const { getServerlessConfig, getOptions } = require('./utils/configUtils')
 
 describe('Serverless warmup plugin constructor', () => {
   it('Should work with only defaults (no config overrides specified)', () => {

--- a/test/constructor.test.js
+++ b/test/constructor.test.js
@@ -499,7 +499,7 @@ describe('Serverless warmup plugin constructor', () => {
     expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
   })
 
-  it('Should use the prewarm from options if present', () => {
+  it('Should use the prewarm option from options if present', () => {
     const serverless = getServerlessConfig({
       service: {
         custom: {
@@ -533,6 +533,244 @@ describe('Serverless warmup plugin constructor', () => {
       enabled: false,
       source: '{"source":"serverless-plugin-warmup"}',
       concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should use the enable option from options if present', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            enabled: true
+          }
+        }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: true,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should use the source from options if present', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            source: {
+              test: 123
+            }
+          }
+        }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '{"test":123}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should stringify the source by default', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            source: '123'
+          }
+        }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '"123"',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should stringify the source if sourceRaw is set to false', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            source: '123',
+            sourceRaw: false
+          }
+        }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '"123"',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should not stringify the source if sourceRaw is set to true', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            source: '123',
+            sourceRaw: true
+          }
+        }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '123',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should use the concurrency from options if present', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            concurrency: 3
+          }
+        }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 3
     }
     expect(plugin.options).toMatchObject(expectedOptions)
     expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)

--- a/test/constructor.test.js
+++ b/test/constructor.test.js
@@ -1,0 +1,564 @@
+/* global describe it expect */
+
+const WarmUP = require('../src/index')
+
+function getServerlessConfig (serverless = {}) {
+  return {
+    getProvider: serverless.getProvider || (() => {}),
+    config: {
+      servicePath: (serverless.config && serverless.config.servicePath) ? serverless.config.servicePath : 'testPath'
+    },
+    cli: console,
+    service: {
+      provider: (serverless.service && serverless.service.provider)
+        ? serverless.service.provider
+        : { stage: '', region: '' },
+      defaults: (serverless.service && serverless.service.defaults)
+        ? serverless.service.defaults
+        : { stage: '', region: '' },
+      service: 'warmup-test',
+      custom: (serverless.service && serverless.service.custom) ? serverless.service.custom : {},
+      functions: (serverless.service && serverless.service.functions) ? serverless.service.functions : {}
+    }
+  }
+}
+
+function getOptions (options = {}) {
+  return options
+}
+
+describe('Serverless warmup plugin constructor', () => {
+  it('Should work with only defaults (no config overrides specified)', () => {
+    const serverless = getServerlessConfig()
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should use the stage and region from defaults if present', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        defaults: { stage: 'staging', region: 'eu-west-1' }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'staging',
+      region: 'eu-west-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-staging-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should use the stage and region from provider if present', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        provider: { stage: 'prod', region: 'eu-west-2' },
+        defaults: { stage: 'staging', region: 'eu-west-1' }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'prod',
+      region: 'eu-west-2'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-prod-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should use the stage and region from options if present', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        provider: { stage: 'prod', region: 'eu-west-2' },
+        defaults: { stage: 'staging', region: 'eu-west-1' }
+      }
+    })
+    const options = getOptions({ stage: 'test', region: 'us-west-2' })
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'test',
+      region: 'us-west-2'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-test-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should use the folder name from custom config', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            folderName: 'test-folder'
+          }
+        }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: 'test-folder',
+      cleanFolder: true,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/test-folder/index.js',
+      pathFolder: 'testPath/test-folder',
+      pathHandler: 'test-folder/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should set clean folder option to true from custom config', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            cleanFolder: true
+          }
+        }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should set clean folder option to false from custom config', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            cleanFolder: false
+          }
+        }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: false,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should use the service name from options if present', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            name: 'test-name'
+          }
+        }
+      }
+    })
+    const options = getOptions({ stage: 'test', region: 'us-west-2' })
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'test',
+      region: 'us-west-2'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'test-name',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should use the service roles from options if present', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            role: 'test-role'
+          }
+        }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: 'test-role',
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should use the service tag from options if present', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            tags: {
+              tag1: 'test-tag-1',
+              tag2: 'test-tag-2'
+            }
+          }
+        }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: {
+        tag1: 'test-tag-1',
+        tag2: 'test-tag-2'
+      },
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should use the service schedule from options if present', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            events: [{ schedule: 'rate(10 minutes)' }]
+          }
+        }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(10 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should use the memory size from options if present', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            memorySize: 256
+          }
+        }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 256,
+      timeout: 10,
+      prewarm: false,
+      enabled: false,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should use the timeout from options if present', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            timeout: 30
+          }
+        }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 30,
+      prewarm: false,
+      enabled: false,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+
+  it('Should use the prewarm from options if present', () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            prewarm: true
+          }
+        }
+      }
+    })
+    const options = getOptions()
+
+    const plugin = new WarmUP(serverless, options)
+
+    const expectedOptions = {
+      stage: 'dev',
+      region: 'us-east-1'
+    }
+    const expectedWarmupOpts = {
+      folderName: '_warmup',
+      cleanFolder: true,
+      name: 'warmup-test-dev-warmup-plugin',
+      pathFile: 'testPath/_warmup/index.js',
+      pathFolder: 'testPath/_warmup',
+      pathHandler: '_warmup/index.warmUp',
+      role: undefined,
+      tags: undefined,
+      events: [{ schedule: 'rate(5 minutes)' }],
+      memorySize: 128,
+      timeout: 10,
+      prewarm: true,
+      enabled: false,
+      source: '{"source":"serverless-plugin-warmup"}',
+      concurrency: 1
+    }
+    expect(plugin.options).toMatchObject(expectedOptions)
+    expect(plugin.warmupOpts).toMatchObject(expectedWarmupOpts)
+  })
+})

--- a/test/hook.afterDeployDeploy.test.js
+++ b/test/hook.afterDeployDeploy.test.js
@@ -1,0 +1,107 @@
+/* global jest describe it expect */
+
+const WarmUP = require('../src/index')
+const { getServerlessConfig, getOptions } = require('./utils/configUtils')
+
+describe('Serverless warmup plugin after:deploy:deploy hook', () => {
+  it('Should prewarm the functions if prewarm is set to true and there are functions', async () => {
+    const mockProvider = { request: jest.fn(() => Promise.resolve()) }
+    const serverless = getServerlessConfig({
+      getProvider () { return mockProvider },
+      service: {
+        custom: {
+          warmup: {
+            enabled: true,
+            prewarm: true
+          }
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:deploy:deploy']()
+
+    expect(mockProvider.request).toHaveBeenCalledTimes(1)
+    const params = {
+      FunctionName: 'warmup-test-dev-warmup-plugin',
+      InvocationType: 'RequestResponse',
+      LogType: 'None',
+      Qualifier: '$LATEST',
+      Payload: '{"source":"serverless-plugin-warmup"}'
+    }
+    expect(mockProvider.request).toHaveBeenCalledWith('Lambda', 'invoke', params)
+  })
+
+  it('Should not prewarm the functions if prewarm is set to true and there are no functions', async () => {
+    const mockProvider = { request: jest.fn(() => Promise.resolve()) }
+    const serverless = getServerlessConfig({
+      getProvider () { return mockProvider },
+      service: {
+        custom: {
+          warmup: {
+            enabled: true,
+            prewarm: true
+          }
+        }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:deploy:deploy']()
+
+    expect(mockProvider.request).not.toHaveBeenCalled()
+  })
+
+  it('Should not prewarm the functions if prewarm is set to false', async () => {
+    const mockProvider = { request: jest.fn(() => Promise.resolve()) }
+    const serverless = getServerlessConfig({
+      getProvider () { return mockProvider },
+      service: {
+        custom: {
+          warmup: {
+            prewarm: false
+          }
+        }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:deploy:deploy']()
+
+    expect(mockProvider.request).not.toHaveBeenCalled()
+  })
+
+  it('Should not error if prewarming fails', async () => {
+    const mockProvider = { request: jest.fn(() => Promise.reject(new Error())) }
+    const serverless = getServerlessConfig({
+      getProvider () { return mockProvider },
+      service: {
+        custom: {
+          warmup: {
+            enabled: true,
+            prewarm: true
+          }
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:deploy:deploy']()
+
+    expect(mockProvider.request).toHaveBeenCalledTimes(1)
+    const params = {
+      FunctionName: 'warmup-test-dev-warmup-plugin',
+      InvocationType: 'RequestResponse',
+      LogType: 'None',
+      Qualifier: '$LATEST',
+      Payload: '{"source":"serverless-plugin-warmup"}'
+    }
+    expect(mockProvider.request).toHaveBeenCalledWith('Lambda', 'invoke', params)
+  })
+})

--- a/test/hook.afterPackageCreateDeploymentArtifacts.test.js
+++ b/test/hook.afterPackageCreateDeploymentArtifacts.test.js
@@ -1,0 +1,80 @@
+/* global jest beforeEach describe it expect */
+
+const WarmUP = require('../src/index')
+const { getServerlessConfig, getOptions } = require('./utils/configUtils')
+
+jest.mock('fs-extra')
+const fs = require('fs-extra')
+
+describe('Serverless warmup plugin after:deploy:deploy hook', () => {
+  beforeEach(() => fs.remove.mockClear())
+
+  it('Should clean the temporary folder if cleanFolder is set to true', async () => {
+    const mockProvider = { request: jest.fn(() => Promise.resolve()) }
+    const serverless = getServerlessConfig({
+      getProvider () { return mockProvider },
+      service: {
+        custom: {
+          warmup: {
+            enabled: true,
+            cleanFolder: true
+          }
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:createDeploymentArtifacts']()
+
+    expect(fs.remove).toHaveBeenCalledTimes(1)
+    expect(fs.remove).toHaveBeenCalledWith('testPath/_warmup')
+  })
+
+  it('Should clean the custom temporary folder if cleanFolder is set to true', async () => {
+    const mockProvider = { request: jest.fn(() => Promise.resolve()) }
+    const serverless = getServerlessConfig({
+      getProvider () { return mockProvider },
+      service: {
+        custom: {
+          warmup: {
+            enabled: true,
+            folderName: 'test-folder',
+            cleanFolder: true
+          }
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:createDeploymentArtifacts']()
+
+    expect(fs.remove).toHaveBeenCalledTimes(1)
+    expect(fs.remove).toHaveBeenCalledWith('testPath/test-folder')
+  })
+
+  it('Should not clean the temporary folder if cleanFolder is set to false', async () => {
+    const mockProvider = { request: jest.fn(() => Promise.resolve()) }
+    const serverless = getServerlessConfig({
+      getProvider () { return mockProvider },
+      service: {
+        custom: {
+          warmup: {
+            enabled: true,
+            cleanFolder: false
+          }
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:createDeploymentArtifacts']()
+
+    expect(fs.remove).not.toHaveBeenCalled()
+  })
+})

--- a/test/hook.afterPackageInitialize.test.js
+++ b/test/hook.afterPackageInitialize.test.js
@@ -1,0 +1,431 @@
+/* global jest beforeEach describe it expect */
+
+const WarmUP = require('../src/index')
+const { getServerlessConfig, getOptions } = require('./utils/configUtils')
+
+jest.mock('fs-extra')
+const fs = require('fs-extra')
+fs.outputFile.mockReturnValue(Promise.resolve())
+
+describe('Serverless warmup plugin constructor', () => {
+  beforeEach(() => fs.outputFile.mockClear())
+
+  it('Should work with only defaults and do nothing', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:initialize']()
+
+    expect(plugin.serverless.service.functions.warmUpPlugin).toBeUndefined()
+  })
+
+  it('Should work with only defaults and do nothing if no functions are enabled', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            enabled: true
+          }
+        },
+        functions: {
+          someFunc1: { name: 'someFunc1', warmup: { enabled: false } },
+          someFunc2: { name: 'someFunc2', warmup: { enabled: false } }
+        }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:initialize']()
+
+    expect(plugin.serverless.service.functions.warmUpPlugin).toBeUndefined()
+  })
+
+  it('Should work with only defaults and do nothing if no functions are enabled', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            enabled: true
+          }
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:initialize']()
+
+    expect(plugin.serverless.service.functions.warmUpPlugin)
+      .toMatchObject({
+        description: 'Serverless WarmUP Plugin',
+        events: [{ schedule: 'rate(5 minutes)' }],
+        handler: '_warmup/index.warmUp',
+        memorySize: 128,
+        name: 'warmup-test-dev-warmup-plugin',
+        runtime: 'nodejs8.10',
+        package: {
+          individually: true,
+          exclude: ['**'],
+          include: ['_warmup/**']
+        },
+        timeout: 10
+      })
+  })
+
+  it('Should use the stage and region from defaults if present', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            enabled: true
+          }
+        },
+        defaults: { stage: 'staging', region: 'eu-west-1' },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:initialize']()
+
+    expect(plugin.serverless.service.functions.warmUpPlugin)
+      .toMatchObject({
+        description: 'Serverless WarmUP Plugin',
+        events: [{ schedule: 'rate(5 minutes)' }],
+        handler: '_warmup/index.warmUp',
+        memorySize: 128,
+        name: 'warmup-test-staging-warmup-plugin',
+        runtime: 'nodejs8.10',
+        package: {
+          individually: true,
+          exclude: ['**'],
+          include: ['_warmup/**']
+        },
+        timeout: 10
+      })
+  })
+
+  it('Should use the stage and region from provider if present', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            enabled: true
+          }
+        },
+        provider: { stage: 'prod', region: 'eu-west-2' },
+        defaults: { stage: 'staging', region: 'eu-west-1' },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:initialize']()
+
+    expect(plugin.serverless.service.functions.warmUpPlugin)
+      .toMatchObject({
+        description: 'Serverless WarmUP Plugin',
+        events: [{ schedule: 'rate(5 minutes)' }],
+        handler: '_warmup/index.warmUp',
+        memorySize: 128,
+        name: 'warmup-test-prod-warmup-plugin',
+        runtime: 'nodejs8.10',
+        package: {
+          individually: true,
+          exclude: ['**'],
+          include: ['_warmup/**']
+        },
+        timeout: 10
+      })
+  })
+
+  it('Should use the stage and region from options if present', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            enabled: true
+          }
+        },
+        provider: { stage: 'prod', region: 'eu-west-2' },
+        defaults: { stage: 'staging', region: 'eu-west-1' },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions({ stage: 'test', region: 'us-west-2' })
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:initialize']()
+
+    expect(plugin.serverless.service.functions.warmUpPlugin)
+      .toMatchObject({
+        description: 'Serverless WarmUP Plugin',
+        events: [{ schedule: 'rate(5 minutes)' }],
+        handler: '_warmup/index.warmUp',
+        memorySize: 128,
+        name: 'warmup-test-test-warmup-plugin',
+        runtime: 'nodejs8.10',
+        package: {
+          individually: true,
+          exclude: ['**'],
+          include: ['_warmup/**']
+        },
+        timeout: 10
+      })
+  })
+
+  it('Should use the folder name from custom config', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            enabled: true,
+            folderName: 'test-folder'
+          }
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:initialize']()
+
+    expect(plugin.serverless.service.functions.warmUpPlugin)
+      .toMatchObject({
+        description: 'Serverless WarmUP Plugin',
+        events: [{ schedule: 'rate(5 minutes)' }],
+        handler: 'test-folder/index.warmUp',
+        memorySize: 128,
+        name: 'warmup-test-dev-warmup-plugin',
+        runtime: 'nodejs8.10',
+        package: {
+          individually: true,
+          exclude: ['**'],
+          include: ['test-folder/**']
+        },
+        timeout: 10
+      })
+  })
+
+  it('Should use the service name from options if present', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            enabled: true,
+            name: 'test-name'
+          }
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions({ stage: 'test', region: 'us-west-2' })
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:initialize']()
+
+    expect(plugin.serverless.service.functions.warmUpPlugin)
+      .toMatchObject({
+        description: 'Serverless WarmUP Plugin',
+        events: [{ schedule: 'rate(5 minutes)' }],
+        handler: '_warmup/index.warmUp',
+        memorySize: 128,
+        name: 'test-name',
+        runtime: 'nodejs8.10',
+        package: {
+          individually: true,
+          exclude: ['**'],
+          include: ['_warmup/**']
+        },
+        timeout: 10
+      })
+  })
+
+  it('Should use the service roles from options if present', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            enabled: true,
+            role: 'test-role'
+          }
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:initialize']()
+
+    expect(plugin.serverless.service.functions.warmUpPlugin)
+      .toMatchObject({
+        description: 'Serverless WarmUP Plugin',
+        events: [{ schedule: 'rate(5 minutes)' }],
+        handler: '_warmup/index.warmUp',
+        memorySize: 128,
+        name: 'warmup-test-dev-warmup-plugin',
+        runtime: 'nodejs8.10',
+        package: {
+          individually: true,
+          exclude: ['**'],
+          include: ['_warmup/**']
+        },
+        timeout: 10,
+        role: 'test-role'
+      })
+  })
+
+  it('Should use the service tag from options if present', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            enabled: true,
+            tags: {
+              tag1: 'test-tag-1',
+              tag2: 'test-tag-2'
+            }
+          }
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:initialize']()
+
+    expect(plugin.serverless.service.functions.warmUpPlugin)
+      .toMatchObject({
+        description: 'Serverless WarmUP Plugin',
+        events: [{ schedule: 'rate(5 minutes)' }],
+        handler: '_warmup/index.warmUp',
+        memorySize: 128,
+        name: 'warmup-test-dev-warmup-plugin',
+        runtime: 'nodejs8.10',
+        package: {
+          individually: true,
+          exclude: ['**'],
+          include: ['_warmup/**']
+        },
+        timeout: 10,
+        tags: {
+          tag1: 'test-tag-1',
+          tag2: 'test-tag-2'
+        }
+      })
+  })
+
+  it('Should use the service schedule from options if present', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            enabled: true,
+            events: [{ schedule: 'rate(10 minutes)' }]
+          }
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:initialize']()
+
+    expect(plugin.serverless.service.functions.warmUpPlugin)
+      .toMatchObject({
+        description: 'Serverless WarmUP Plugin',
+        events: [{ schedule: 'rate(10 minutes)' }],
+        handler: '_warmup/index.warmUp',
+        memorySize: 128,
+        name: 'warmup-test-dev-warmup-plugin',
+        runtime: 'nodejs8.10',
+        package: {
+          individually: true,
+          exclude: ['**'],
+          include: ['_warmup/**']
+        },
+        timeout: 10
+      })
+  })
+
+  it('Should use the memory size from options if present', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            enabled: true,
+            memorySize: 256
+          }
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:initialize']()
+
+    expect(plugin.serverless.service.functions.warmUpPlugin)
+      .toMatchObject({
+        description: 'Serverless WarmUP Plugin',
+        events: [{ schedule: 'rate(5 minutes)' }],
+        handler: '_warmup/index.warmUp',
+        memorySize: 256,
+        name: 'warmup-test-dev-warmup-plugin',
+        runtime: 'nodejs8.10',
+        package: {
+          individually: true,
+          exclude: ['**'],
+          include: ['_warmup/**']
+        },
+        timeout: 10
+      })
+  })
+
+  it('Should use the timeout from options if present', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            enabled: true,
+            timeout: 30
+          }
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const options = getOptions()
+    const plugin = new WarmUP(serverless, options)
+
+    await plugin.hooks['after:package:initialize']()
+
+    expect(plugin.serverless.service.functions.warmUpPlugin)
+      .toMatchObject({
+        description: 'Serverless WarmUP Plugin',
+        events: [{ schedule: 'rate(5 minutes)' }],
+        handler: '_warmup/index.warmUp',
+        memorySize: 128,
+        name: 'warmup-test-dev-warmup-plugin',
+        runtime: 'nodejs8.10',
+        package: {
+          individually: true,
+          exclude: ['**'],
+          include: ['_warmup/**']
+        },
+        timeout: 30
+      })
+  })
+})

--- a/test/utils/configUtils.js
+++ b/test/utils/configUtils.js
@@ -1,0 +1,33 @@
+function getServerlessConfig (serverless = {}) {
+  return {
+    getProvider: serverless.getProvider || (() => {}),
+    config: {
+      servicePath: (serverless.config && serverless.config.servicePath) ? serverless.config.servicePath : 'testPath'
+    },
+    cli: {
+      log() {}
+    },
+    service: {
+      provider: (serverless.service && serverless.service.provider)
+        ? serverless.service.provider
+        : { stage: '', region: '' },
+      defaults: (serverless.service && serverless.service.defaults)
+        ? serverless.service.defaults
+        : { stage: '', region: '' },
+      service: 'warmup-test',
+      custom: (serverless.service && serverless.service.custom) ? serverless.service.custom : {},
+      getAllFunctions() { return Object.keys(this.functions) },
+      getFunction(name) { return this.functions[name] },
+      functions: (serverless.service && serverless.service.functions) ? serverless.service.functions : {}
+    }
+  }
+}
+
+function getOptions (options = {}) {
+  return options
+}
+
+module.exports = {
+  getServerlessConfig,
+  getOptions
+}

--- a/test/utils/configUtils.js
+++ b/test/utils/configUtils.js
@@ -15,7 +15,7 @@ function getServerlessConfig (serverless = {}) {
         ? serverless.service.defaults
         : { stage: '', region: '' },
       service: 'warmup-test',
-      custom: (serverless.service && serverless.service.custom) ? serverless.service.custom : {},
+      custom: serverless.service ? serverless.service.custom : undefined,
       getAllFunctions() { return Object.keys(this.functions) },
       getFunction(name) { return this.functions[name] },
       functions: (serverless.service && serverless.service.functions) ? serverless.service.functions : {}


### PR DESCRIPTION
This PR adds tests for pretty much everything except for the generated function which should be tested in every function inside `test/hook.afterPackageInitialize.test.js` using the approach of #111

Missing tests include:
* Global enabled
* Global disabled
* Global stage
* Global stages

* Global enabled - function disabled
* Global enabled - function stage
* Global enabled - function stages array

* Global disabled - function enabled
* Global disabled - function stage
* Global disabled - function stages array

* Global stage - function enabled
* Global stage - function disabled
* Global stage - function stages array


* Global stages array - function enabled
* Global stages array - function disabled
* Global stages array - function stage

* source
* source raw

* concurrency