### PR TITLE
Add tests for generated function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,7 @@ class WarmUP {
         : defaultOpts.enabled,
       source: (typeof config.source !== 'undefined')
         ? (config.sourceRaw ? config.source : JSON.stringify(config.source))
-        : (defaultOpts.sourceRaw ? defaultOpts.source : JSON.stringify(defaultOpts.source)),
+        : defaultOpts.source,
       concurrency: (typeof config.concurrency === 'number') ? config.concurrency : defaultOpts.concurrency
     }
   }
@@ -187,7 +187,7 @@ class WarmUP {
 
     const functionDefaultOpts = {
       enabled: false,
-      source: { source: 'serverless-plugin-warmup' },
+      source: JSON.stringify({ source: 'serverless-plugin-warmup' }),
       concurrency: 1
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -252,7 +252,7 @@ aws.config.region = "${this.options.region}";
 const lambda = new aws.Lambda();
 const functions = ${JSON.stringify(functions)};
 
-module.exports.warmUp = async (event, context, callback) => {
+module.exports.warmUp = async (event, context) => {
   console.log("Warm Up Start");
   
   const invokes = await Promise.all(functions.map(async (func) => {

--- a/test/utils/generatedFunctionTester.js
+++ b/test/utils/generatedFunctionTester.js
@@ -1,0 +1,38 @@
+class GeneratedFunctionTester {
+  constructor(func) {
+    this.func = func
+    this.lambdaInstances = []
+    this.aws = {
+      config: {},
+      Lambda: jest.fn().mockImplementation(() => {
+        const invoke = jest.fn().mockReturnValue(Promise.resolve())
+        this.lambdaInstances.push(invoke)
+        return { invoke }
+      })
+    }
+  }
+
+  generatedWarmupFunction() {
+    return new Function('dependencies', `
+      console = {
+        log: () => {}
+      };
+      const require = (dep) => {
+        if (!dependencies[dep]) {
+          throw new Error(\`Unknow dependency (\${dep})\`);
+        }
+
+        return dependencies[dep];
+      };
+      const module = { exports: {} };
+      ${this.func}
+      module.exports.warmUp();
+    `)
+  }
+
+  executeWarmupFunction() {
+    this.generatedWarmupFunction()({ 'aws-sdk': this.aws })
+  }
+} 
+
+module.exports = { GeneratedFunctionTester };


### PR DESCRIPTION
Takes the idea of #111 a bit further creating a helper class and adding tests for all the function level configs.