### PR TITLE
Add cleaner runtime type validation

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,88 @@
+const isObject = val =>
+  Object.prototype.toString.call(val) === '[object Object]'
+
+const isType = (val, type) => {
+  switch (type) {
+    case 'object':
+      return isObject(val)
+    case 'array':
+      return Array.isArray(val)
+    case 'null':
+      return val === null
+    default:
+      return typeof val === type; // eslint-disable-line
+  }
+}
+
+const _validate = (
+  sourceObj,
+  types,
+  defaults,
+  hasDefaults = isObject(defaults)
+) => {
+  const returnObj = {}
+
+  for (const key of Object.keys(types)) {
+    const typeDefinition = types[key]
+    const allowedTypes = Array.isArray(typeDefinition.type)
+      ? typeDefinition.type
+      : [typeDefinition.type]
+
+    if (allowedTypes.some(allowedType => isType(sourceObj[key], allowedType))) {
+      returnObj[key] = sourceObj[key]
+    } else if (hasDefaults && defaults[key] !== undefined) {
+      returnObj[key] = defaults[key]
+    }
+
+    const requiredPropNotPresent =
+      typeDefinition.optional !== true && returnObj[key] === undefined
+
+    const propPresentButInvalid =
+      returnObj[key] !== undefined &&
+      !allowedTypes.some(allowedType => isType(returnObj[key], allowedType))
+
+    if (requiredPropNotPresent || propPresentButInvalid) {
+      throw Error(
+        `Validation error for ${key}, expected ${allowedTypes.join(
+          ' / '
+        )}, got ${returnObj[key]}`
+      )
+    }
+  }
+
+  return returnObj
+}
+
+function ensureObject (val, fallback = {}) {
+  return isObject(val) ? val : fallback
+}
+
+class Validator {
+  constructor (source) {
+    this.source = source
+  }
+
+  validate () {
+    if (!isObject(this.types)) {
+      throw Error('Validation error: no types provided')
+    }
+    return _validate(this.source, this.types, this.defaults)
+  }
+
+  withTypes (types) {
+    this.types = types
+    return this
+  }
+
+  withDefaults (defaults) {
+    this.defaults = defaults
+    return this
+  }
+}
+
+module.exports = {
+  ensureObject,
+  isObject,
+  isType,
+  Validator
+}

--- a/test/constructor.test.js
+++ b/test/constructor.test.js
@@ -21,8 +21,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -56,8 +54,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -92,8 +88,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -128,8 +122,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -167,8 +159,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/test-folder/index.js',
       pathFolder: 'testPath/test-folder',
       pathHandler: 'test-folder/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -206,8 +196,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -245,8 +233,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -284,8 +270,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -324,7 +308,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
       role: 'test-role',
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -365,7 +348,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
       tags: {
         tag1: 'test-tag-1',
         tag2: 'test-tag-2'
@@ -391,7 +373,10 @@ describe('Serverless warmup plugin constructor', () => {
             vpc: false
           }
         },
-        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+        functions: {
+          someFunc1: { name: 'someFunc1' },
+          someFunc2: { name: 'someFunc2' }
+        }
       }
     })
     const options = getOptions()
@@ -409,8 +394,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       vpc: { securityGroupIds: [], subnetIds: [] },
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
@@ -430,10 +413,16 @@ describe('Serverless warmup plugin constructor', () => {
         custom: {
           warmup: {
             enabled: true,
-            vpc: { securityGroupIds: ['sg-test1', 'sg-test2'], subnetIds: ['sn-test1', 'sn-test2'] }
+            vpc: {
+              securityGroupIds: ['sg-test1', 'sg-test2'],
+              subnetIds: ['sn-test1', 'sn-test2']
+            }
           }
         },
-        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+        functions: {
+          someFunc1: { name: 'someFunc1' },
+          someFunc2: { name: 'someFunc2' }
+        }
       }
     })
     const options = getOptions()
@@ -450,9 +439,10 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
-      vpc: { securityGroupIds: ['sg-test1', 'sg-test2'], subnetIds: ['sn-test1', 'sn-test2'] },
+      vpc: {
+        securityGroupIds: ['sg-test1', 'sg-test2'],
+        subnetIds: ['sn-test1', 'sn-test2']
+      },
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -490,8 +480,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(10 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -529,8 +517,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 256,
       timeout: 10,
@@ -568,8 +554,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 30,
@@ -607,8 +591,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -646,8 +628,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -687,8 +667,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -726,8 +704,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -766,8 +742,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -806,8 +780,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -845,8 +817,6 @@ describe('Serverless warmup plugin constructor', () => {
       pathFile: 'testPath/_warmup/index.js',
       pathFolder: 'testPath/_warmup',
       pathHandler: '_warmup/index.warmUp',
-      role: undefined,
-      tags: undefined,
       events: [{ schedule: 'rate(5 minutes)' }],
       memorySize: 128,
       timeout: 10,
@@ -868,7 +838,10 @@ describe('Serverless warmup plugin constructor', () => {
               default: true
             }
           },
-          functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+          functions: {
+            someFunc1: { name: 'someFunc1' },
+            someFunc2: { name: 'someFunc2' }
+          }
         }
       })
       const options = getOptions()
@@ -886,8 +859,6 @@ describe('Serverless warmup plugin constructor', () => {
         pathFile: 'testPath/_warmup/index.js',
         pathFolder: 'testPath/_warmup',
         pathHandler: '_warmup/index.warmUp',
-        role: undefined,
-        tags: undefined,
         events: [{ schedule: 'rate(5 minutes)' }],
         memorySize: 128,
         timeout: 10,
@@ -908,7 +879,10 @@ describe('Serverless warmup plugin constructor', () => {
               default: 'dev'
             }
           },
-          functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+          functions: {
+            someFunc1: { name: 'someFunc1' },
+            someFunc2: { name: 'someFunc2' }
+          }
         }
       })
       const options = getOptions()
@@ -926,8 +900,6 @@ describe('Serverless warmup plugin constructor', () => {
         pathFile: 'testPath/_warmup/index.js',
         pathFolder: 'testPath/_warmup',
         pathHandler: '_warmup/index.warmUp',
-        role: undefined,
-        tags: undefined,
         events: [{ schedule: 'rate(5 minutes)' }],
         memorySize: 128,
         timeout: 10,
@@ -965,8 +937,6 @@ describe('Serverless warmup plugin constructor', () => {
         pathFile: 'testPath/_warmup/index.js',
         pathFolder: 'testPath/_warmup',
         pathHandler: '_warmup/index.warmUp',
-        role: undefined,
-        tags: undefined,
         events: [{ schedule: 'rate(5 minutes)' }],
         memorySize: 128,
         timeout: 10,
@@ -1004,8 +974,6 @@ describe('Serverless warmup plugin constructor', () => {
         pathFile: 'testPath/_warmup/index.js',
         pathFolder: 'testPath/_warmup',
         pathHandler: '_warmup/index.warmUp',
-        role: undefined,
-        tags: undefined,
         events: [{ schedule: 'rate(10 minutes)' }],
         memorySize: 128,
         timeout: 10,
@@ -1043,9 +1011,10 @@ describe('Serverless warmup plugin constructor', () => {
         pathFile: 'testPath/_warmup/index.js',
         pathFolder: 'testPath/_warmup',
         pathHandler: '_warmup/index.warmUp',
-        role: undefined,
-        tags: undefined,
-        events: [{ schedule: 'rate(10 minutes)' }, { schedule: 'rate(30 minutes)' }],
+        events: [
+          { schedule: 'rate(10 minutes)' },
+          { schedule: 'rate(30 minutes)' }
+        ],
         memorySize: 128,
         timeout: 10,
         prewarm: false,


### PR DESCRIPTION
Wrote a pretty simple validator helper that (IMO) makes the main module a bit easier to read through. Also changed a bunch of if-statement truthiness checks to assert the expected value more explicitly.

...also forgot to turn prettier autoformat off, but it's probably not a big deal.

TODO: unit tests for the validator helper