### PR TITLE
Rename source to payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ functions:
 #### Options that can be overridden per function
 
 * **enabled** (default `false`)
-* **source** (default `{ "source": "serverless-plugin-warmup" }`)
-* **sourceRaw** (default `false`)
+* **payload** (default `{ "source": "serverless-plugin-warmup" }`)
+* **payloadRaw** (default `false`)
 * **concurrency** (default `1`)
 
 ```yml
@@ -152,8 +152,10 @@ custom:
       - schedule: 'cron(0/5 8-17 ? * MON-FRI *)' # Run WarmUP every 5 minutes Mon-Fri between 8:00am and 5:55pm (UTC)
     timeout: 20
     prewarm: true # Run WarmUp immediately after a deploymentlambda
-    source: '{ "source": "my-custom-payload" }'
-    sourceRaw: true # Won't JSON.stringify() the source, may be necessary for Go/AppSync deployments
+    payload: 
+      source: my-custom-source
+      other: 20
+    payloadRaw: true # Won't JSON.stringify() the source, may be necessary for Go/AppSync deployments
     concurrency: 5 # Warm up 5 concurrent instances
 ```
 
@@ -180,6 +182,8 @@ However, they are listed here only to facilitate upgrading the pluging and we st
 
 * **default** Has been renamed to `enabled`
 * **schedule** `schedule: rate(5 minutes)` is equivalent to `events: - schedule: rate(5 minutes)`.
+* **source** Has been renamed to `payload`
+* **sourceRaw** Has been renamed to `payloadRaw`
 
 ### Permissions
 
@@ -291,7 +295,7 @@ module.exports.lambdaToWarm = function(event, context, callback) {
   ... add lambda logic after
 }
 ```
-You can also check for the warmp event using the `context` variable. This could be useful if you are handling the raw input and output streams:
+You can also check for the warmup event using the `context` variable. This could be useful if you are handling the raw input and output streams:
 
 ```javascript
 ...

--- a/src/index.js
+++ b/src/index.js
@@ -155,6 +155,9 @@ class WarmUP {
     if (config.default) {
       config.enabled = possibleConfig.default
     }
+    if (config.source) {
+      config.payload = possibleConfig.source
+    }
 
     return {
       enabled: (typeof config.enabled === 'boolean' ||
@@ -162,9 +165,9 @@ class WarmUP {
           Array.isArray(config.enabled))
         ? config.enabled
         : defaultOpts.enabled,
-      source: (typeof config.source !== 'undefined')
-        ? (config.sourceRaw ? config.source : JSON.stringify(config.source))
-        : defaultOpts.source,
+      payload: (typeof config.payload !== 'undefined')
+        ? (typeof config.payload === 'string' ? config.payload : JSON.stringify(config.payload))
+        : defaultOpts.payload,
       concurrency: (typeof config.concurrency === 'number') ? config.concurrency : defaultOpts.concurrency
     }
   }
@@ -187,7 +190,7 @@ class WarmUP {
 
     const functionDefaultOpts = {
       enabled: false,
-      source: JSON.stringify({ source: 'serverless-plugin-warmup' }),
+      payload: JSON.stringify({ source: 'serverless-plugin-warmup' }),
       concurrency: 1
     }
 
@@ -259,12 +262,12 @@ module.exports.warmUp = async (event, context) => {
     console.log(\`Warming up function: \${func.name} with concurrency: \${func.config.concurrency}\`);
     
     const params = {
-      ClientContext: Buffer.from(\`{"custom":\${func.config.source}}\`).toString('base64'),
+      ClientContext: Buffer.from(\`{"custom":\${func.config.payload}}\`).toString('base64'),
       FunctionName: func.name,
       InvocationType: "RequestResponse",
       LogType: "None",
       Qualifier: process.env.SERVERLESS_ALIAS || "$LATEST",
-      Payload: func.config.source
+      Payload: func.config.payload
     };
     
     try {
@@ -339,7 +342,7 @@ module.exports.warmUp = async (event, context) => {
       InvocationType: 'RequestResponse',
       LogType: 'None',
       Qualifier: process.env.SERVERLESS_ALIAS || '$LATEST',
-      Payload: this.warmupOpts.source
+      Payload: this.warmupOpts.payload
     }
 
     return this.provider.request('Lambda', 'invoke', params)


### PR DESCRIPTION
I find `source` a really misleading name since it actually indicates the payload which by default is `{ source: 'serverless-plugin-warmup' }`.

`payload` is a much more clear name.
As with other property changes, the plugin will stay backwards compatible.