### PR TITLE
Fix to take on account custom variables inside external {file}

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,6 @@ class WarmUP {
       (this.serverless.service.defaults && this.serverless.service.defaults.region) ||
       'us-east-1'
 
-    this.warmupOpts = this.configPlugin(this.serverless.service, this.options.stage)
   }
 
   /**
@@ -58,6 +57,7 @@ class WarmUP {
    * @return {Promise}
    * */
   async afterPackageInitialize () {
+    this.warmupOpts = this.configPlugin(this.serverless.service, this.options.stage)
     this.functionsToWarmup = this.getFunctionsToBeWarmedUp(this.serverless.service, this.options.stage, this.warmupOpts)
 
     if (!this.functionsToWarmup.length) {


### PR DESCRIPTION
Hello!

I was using your Plugin but it does not take on account when you separate the configurations

In my yml i use in this way.:

service: service-name

provider:
  name: aws
  runtime: nodejs8.10

custom: ${file(ymls/custom.yml)}
resources: ${file(ymls/resources.yml)}
functions: ${file(ymls/functions.yml)}

In the custom file:
warmup:
  default: false
  prewarm: true
  cleanFolder: false
  role: warmupRole
  memorySize: 128
  schedule: cron(0/5 6-20 ? * * *)
  timeout: 20

[]s.