### PR TITLE
Handle enabled field with boolean value as string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -216,6 +216,7 @@ class WarmUP {
       .map(config => ({ name: config.name, config: this.getFunctionConfig(config.warmup, warmupOpts) }))
       .filter(({ config: { enabled } }) => (
         enabled === true ||
+        enabled === 'true' ||
         enabled === stage ||
         (Array.isArray(enabled) && enabled.indexOf(stage) !== -1)
       ))


### PR DESCRIPTION
The goal of this PR is to allow the plugin setup using boolean as string like the scenario below:

```yml
  warmup:
    enabled: ${env:WARM_UP_ENABLED}
```

In the scenario above the value of `WARM_UP_ENABLED` is a string `"true"` and the plugin skips the creation of the warm function. With the PR the function will be created. 

The env var in question is set on a deployment shell script.