### PR TITLE
Allow warmup function to be packaged as part of main serverless bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ functions:
 * **events** (default `- schedule: rate(5 minutes)`)
 * **timeout** (default `10` seconds)
 * **prewarm** (default `false`)
+* **packageIndividually** (default `true`)
 
 #### Options that can be overridden per function
 
@@ -159,7 +160,8 @@ custom:
       - schedule: 'cron(0/5 8-17 ? * MON-FRI *)' # Run WarmUp every 5 minutes Mon-Fri between 8:00am and 5:55pm (UTC)
     timeout: 20
     prewarm: true # Run WarmUp immediately after a deploymentlambda
-    payload: 
+    packageIndividually: true # Package warmup function individually
+    payload:
       source: my-custom-source
       other: 20
     payloadRaw: true # Won't JSON.stringify() the source, may be necessary for Go/AppSync deployments

--- a/test/hook.afterPackageInitialize.test.js
+++ b/test/hook.afterPackageInitialize.test.js
@@ -1431,6 +1431,26 @@ describe('Serverless warmup plugin constructor', () => {
     }
   })
 
+  it('Should not package individually if specified in params', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            enabled: true,
+            packageIndividually: false
+          }
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } }
+      }
+    })
+    const plugin = new WarmUp(serverless, {})
+
+    await plugin.hooks['after:package:initialize']()
+
+    expect(plugin.serverless.service.functions.warmUpPlugin)
+      .toEqual(getExpectedFunctionConfig({ package: undefined }))
+  })
+
   describe('Backwards compatibility', () => {
     it('Should accept backwards compatible "default" as boolean property in place of "enabled"', async () => {
       const serverless = getServerlessConfig({


### PR DESCRIPTION
### Background

When warmup plugin is used together with some other serverless plugins (e.g epsagon for instrumentation) the warmup functions can be wrapped in another handler and gets additional dependencies.

In this case the individual packaging doesn't work anymore as there are additional files needed to be packaged.

### Solution

For this case I added a parameter to allow warmup to be packaged as part of the main "bundle".
That makes one large package instead of 2 separate ones, but I found in most cases I tend to deploy full bundle anyway.

I still left default as is now, so there should be no impact if parameter is not passed in explicitly