### PR TITLE
Feature/layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Most options are set under `custom.warmup` in the `serverless.yaml` file.
 * **package** (default `package: { individually: true, exclude: ['**'], include: ['_warmup/**'] }`)
 * **timeout** (default `10` seconds)
 * **prewarm** (default `false`)
+* **layers** (default `undefined`) can add layers used in your project (e.g. shared layer with `node_modules`). When using shared `node_modules` remember to set environment variable `NODE_PATH: "./:/opt/node_modules"`
 
 But there are some options which can also be set under `custom.warmup` to be applied to all lambdas to be warmed up or can be overridden on each individual lambda.
 
@@ -80,6 +81,8 @@ custom:
         - ./**
     timeout: 20
     prewarm: true # Run WarmUp immediately after a deploymentlambda
+    layers: 
+      - myLayerName
     payload: 
       source: my-custom-source
       other: 20
@@ -89,6 +92,8 @@ custom:
 functions:
   myColdfunction:
     handler: 'myColdfunction.handler'
+    layers: 
+      - myLayerName
     events:
       - http:
           path: my-cold-function

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-warmup",
-  "version": "4.3.3-rc.1",
+  "version": "4.4.3-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1898,7 +1898,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1919,12 +1920,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1939,17 +1942,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2066,7 +2072,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2078,6 +2085,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2092,6 +2100,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2099,12 +2108,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2123,6 +2134,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2203,7 +2215,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2215,6 +2228,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2300,7 +2314,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2336,6 +2351,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2355,6 +2371,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2398,12 +2415,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/index.js
+++ b/src/index.js
@@ -178,7 +178,9 @@ class WarmUp {
       memorySize: (typeof config.memorySize === 'number') ? config.memorySize : defaultOpts.memorySize,
       timeout: (typeof config.timeout === 'number') ? config.timeout : defaultOpts.timeout,
       prewarm: (typeof config.prewarm === 'boolean') ? config.prewarm : defaultOpts.prewarm,
-      layers: (Array.isArray(config.layers) && config.layers.length > 0) ? config.layers : defaultOpts.layers
+      layers: (Array.isArray(config.layers) && config.layers.length > 0)
+        ? config.layers
+        : defaultOpts.layers,
     };
     /* eslint-enable no-nested-ternary */
   }
@@ -359,7 +361,7 @@ module.exports.warmUp = async (event, context) => {
         runtime: 'nodejs8.10',
         package: this.warmupOpts.package,
         timeout: this.warmupOpts.timeout,
-        layers: this.warmup.layers
+        layers: this.warmupOpts.layers,
       },
       this.warmupOpts.role ? { role: this.warmupOpts.role } : {},
       this.warmupOpts.tags ? { tags: this.warmupOpts.tags } : {},

--- a/src/index.js
+++ b/src/index.js
@@ -178,6 +178,7 @@ class WarmUp {
       memorySize: (typeof config.memorySize === 'number') ? config.memorySize : defaultOpts.memorySize,
       timeout: (typeof config.timeout === 'number') ? config.timeout : defaultOpts.timeout,
       prewarm: (typeof config.prewarm === 'boolean') ? config.prewarm : defaultOpts.prewarm,
+      layers: (Array.isArray(config.layers) && config.layers.length > 0) ? config.layers : defaultOpts.layers
     };
     /* eslint-enable no-nested-ternary */
   }
@@ -358,6 +359,7 @@ module.exports.warmUp = async (event, context) => {
         runtime: 'nodejs8.10',
         package: this.warmupOpts.package,
         timeout: this.warmupOpts.timeout,
+        layers: this.warmup.layers
       },
       this.warmupOpts.role ? { role: this.warmupOpts.role } : {},
       this.warmupOpts.tags ? { tags: this.warmupOpts.tags } : {},

--- a/test/hook.afterPackageInitialize.test.js
+++ b/test/hook.afterPackageInitialize.test.js
@@ -1230,6 +1230,28 @@ describe('Serverless warmup plugin constructor', () => {
       }));
   });
 
+  it('Should use the layer from options if present', async () => {
+    const serverless = getServerlessConfig({
+      service: {
+        custom: {
+          warmup: {
+            enabled: true,
+            layers: ['sampleLayer'],
+          },
+        },
+        functions: { someFunc1: { name: 'someFunc1' }, someFunc2: { name: 'someFunc2' } },
+      },
+    });
+    const plugin = new WarmUp(serverless, {});
+
+    await plugin.hooks['after:package:initialize']();
+
+    expect(plugin.serverless.service.functions.warmUpPlugin)
+      .toEqual(getExpectedFunctionConfig({
+        layers: ['sampleLayer'],
+      }));
+  });
+
   it('Should use the source from options if present', async () => {
     const serverless = getServerlessConfig({
       service: {


### PR DESCRIPTION
Implemented `WarmUp` function layers. [Lambda layer ref](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
Layers (max 5.) can be added in `custom.warmup.layers`. 

They are very useful if you have `nodeExternals` implemented.  Then `node_modules` is shared between lambdas by being placed on shared layer. Lambdas can be deployed without `node_modules` since they are available on runtime by layer.
With that architecture required by `WarmUp` function module `aws-sdk` should be in `node_modules` of used layer. Remember to set environment variable `NODE_PATH: "./:/opt/node_modules"`