### PR TITLE
Support dynamically overriding concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ functions:
 * Day cold periods
 * Desire to avoid cold lambdas after a deployment
 
+#### Runtime Configuration
+Concurrency can be modified post-deployment at runtime by use of Lambda environment variables.  
+Two configuration options exist:
+* Globally set the concurrency of all lambdas on a stack (overriding any deployment config function or global values):  
+  Set the environment variable `GLOBAL_WARMUP_CONCURRENCY`
+* Individually set the concurrency per lambda  
+  Set the environment variable `WARMUP_CONCURRENCY_YOUR_FUNCTION_NAME`. `-` is replaced with `_`. Must be all uppercase. 
 
 #### Legacy options
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Two configuration options exist:
 * Globally set the concurrency of all lambdas on the stack (overriding the deployment configuration):  
   Set the environment variable `WARMUP_CONCURRENCY`
 * Individually set the concurrency per lambda  
-  Set the environment variable WARMUP_CONCURRENCY_YOUR_FUNCTION_NAME. Must be all uppercase and hyphens (-) are replaced with underscores (_) 
+  Set the environment variable WARMUP_CONCURRENCY_YOUR_FUNCTION_NAME. Must be all uppercase and hyphens (-) are replaced with underscores (_). If present, it overrides the global concurrency setting. 
 
 #### Legacy options
 

--- a/README.md
+++ b/README.md
@@ -135,12 +135,12 @@ functions:
 * Desire to avoid cold lambdas after a deployment
 
 #### Runtime Configuration
-Concurrency can be modified post-deployment at runtime by use of Lambda environment variables.  
+Concurrency can be modified post-deployment at runtime by using Lambda environment variables.  
 Two configuration options exist:
-* Globally set the concurrency of all lambdas on a stack (overriding any deployment config function or global values):  
-  Set the environment variable `GLOBAL_WARMUP_CONCURRENCY`
+* Globally set the concurrency of all lambdas on the stack (overriding the deployment configuration):  
+  Set the environment variable `WARMUP_CONCURRENCY`
 * Individually set the concurrency per lambda  
-  Set the environment variable `WARMUP_CONCURRENCY_YOUR_FUNCTION_NAME`. `-` is replaced with `_`. Must be all uppercase. 
+  Set the environment variable WARMUP_CONCURRENCY_YOUR_FUNCTION_NAME. Must be all uppercase and hyphens (-) are replaced with underscores (_) 
 
 #### Legacy options
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4059,7 +4059,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -4691,7 +4691,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4059,7 +4059,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -4691,7 +4691,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },

--- a/src/index.js
+++ b/src/index.js
@@ -317,18 +317,20 @@ module.exports.warmUp = async (event, context) => {
   console.log("Warm Up Start");
   
   const invokes = await Promise.all(functions.map(async (func) => {
-    let concurrency = func.config.concurrency;
+    let concurrency;
     const functionConcurrency = process.env["WARMUP_CONCURRENCY_" + func.name.toUpperCase().replace(/-/g, '_')]
     
     if (functionConcurrency) {
       concurrency = parseInt(functionConcurrency);
-      console.log(\`Function environment variable warmup concurrency found: \${concurrency}. Overwrote configured concurrency for \${func.name}\`);
+      console.log(\`Warming up function: \${func.name} with concurrency: \${concurrency} (from function-specific environment variable)\`);
     } else if (process.env.WARMUP_CONCURRENCY) {
       concurrency = parseInt(process.env.WARMUP_CONCURRENCY);
-      console.log(\`Global environment variable warmup concurrency found: \${concurrency}. Overwrote configured concurrency for \${func.name}\`);
+      console.log(\`Warming up function: \${func.name} with concurrency: \${concurrency} (from global environment variable)\`);
+    } else {
+      concurrency = func.config.concurrency;
+      console.log(\`Warming up function: \${func.name} with concurrency: \${concurrency}\`);
     }
     
-    console.log(\`Warming up function: \${func.name} with concurrency: \${concurrency}\`);
     
     const params = {
       ClientContext: Buffer.from(\`{"custom":\${func.config.payload}}\`).toString('base64'),

--- a/src/index.js
+++ b/src/index.js
@@ -317,15 +317,15 @@ module.exports.warmUp = async (event, context) => {
   console.log("Warm Up Start");
   
   const invokes = await Promise.all(functions.map(async (func) => {
+    let concurrency = func.config.concurrency;
     const functionConcurrency = process.env["WARMUP_CONCURRENCY_" + func.name.toUpperCase().replace(/-/g, '_')]
     
-    let concurrency = func.config.concurrency;
-    if (process.env.GLOBAL_WARMUP_CONCURRENCY) {
-      concurrency = parseInt(process.env.GLOBAL_WARMUP_CONCURRENCY);
-      console.log(\`Global environment variable warmup concurrency found: \${concurrency}. Overwrote configured concurrency for \${func.name}\`);
-    } else if (functionConcurrency) {
+    if (functionConcurrency) {
       concurrency = parseInt(functionConcurrency);
       console.log(\`Function environment variable warmup concurrency found: \${concurrency}. Overwrote configured concurrency for \${func.name}\`);
+    } else if (process.env.WARMUP_CONCURRENCY) {
+      concurrency = parseInt(process.env.WARMUP_CONCURRENCY);
+      console.log(\`Global environment variable warmup concurrency found: \${concurrency}. Overwrote configured concurrency for \${func.name}\`);
     }
     
     console.log(\`Warming up function: \${func.name} with concurrency: \${concurrency}\`);


### PR DESCRIPTION
We have a use case to dynamically change the warmup concurrency of our lambdas across different stacks at runtime rather than requiring a code change and deployment. I think this is really useful as sometimes we'd like to smooth out adhoc burst traffic we know will be coming without having to redeploy every stack.

This code change allows us to modify the concurrency of all lambdas, or just individual lambdas by just adding an environment variable.

The output looks like this:
```
2019-06-13T00:24:18.472Z	a92c57be-d4d7-40ed-b055-652fcc2bd45c	Warming up function: test-lambda with concurrency: 1
2019-06-13T00:24:18.550Z	a92c57be-d4d7-40ed-b055-652fcc2bd45c	Function environment variable warmup concurrency found: 5. Overwrote configured concurrency for test-lambda-2
2019-06-13T00:24:18.550Z	a92c57be-d4d7-40ed-b055-652fcc2bd45c	Warming up function: test-lambda-2 with concurrency: 5
```
by setting `WARMUP_CONCURRENCY_TEST_LAMBDA_2 = 5` in the AWS console for lambda's environment variables.

fixes #160 