### PR TITLE
Patch: concurrency from config force Number

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -330,7 +330,7 @@ module.exports.warmUp = async (event, context) => {
       concurrency = parseInt(process.env.WARMUP_CONCURRENCY);
       console.log(\`Warming up function: \${func.name} with concurrency: \${concurrency} (from global environment variable)\`);
     } else {
-      concurrency = func.config.concurrency;
+      concurrency = parseInt(func.config.concurrency);
       console.log(\`Warming up function: \${func.name} with concurrency: \${concurrency}\`);
     }
 


### PR DESCRIPTION
While playing with this wonderful plugin, I stumbled upon the following issue

```yml
service: debug

functions:
  handler:
    handler: index.handler
    package:
      artifact: app.zip
    warmup:
      concurrency: ${ssm:/patch/to/variable} # value "50"
```

Due to limitations from SSM Parameter Store, values are stored as `str`, while the handler in warmup assumes this is an `int`

```js
const functions = [
  {
    "name": "debug-dev",
    "config": {
      "enabled": true,
      "payload": "{\"source\":\"serverless-plugin-warmup\"}",
      "concurrency": "50"
    }
  }
];
```

This patch allows user to setup any valid expression `parseInt` accepts