### PR TITLE
Update readme to use correct policy version

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ resources:
         Path: /my/cust/path/
         RoleName: MyCustRole0
         AssumeRolePolicyDocument:
-          Version: '2017'
+          Version: '2012-10-17'
           Statement:
             - Effect: Allow
               Principal:
@@ -193,7 +193,7 @@ resources:
         Policies:
           - PolicyName: myPolicyName
             PolicyDocument:
-              Version: '2017'
+              Version: '2012-10-17'
               Statement:
                 - Effect: Allow # WarmUp lamda to send logs to CloudWatch
                   Action:


### PR DESCRIPTION
According to https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_version.html only two values are accepted. This commit changes the invalid value to the most recent of the two acceptable version strings.