### PR TITLE
update nodejs runtime to 12.x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -372,7 +372,7 @@ module.exports.warmUp = async (event, context) => {
       handler: warmupOpts.pathHandler,
       memorySize: warmupOpts.memorySize,
       name: warmupOpts.name,
-      runtime: 'nodejs10.x',
+      runtime: 'nodejs12.x',
       package: warmupOpts.package,
       timeout: warmupOpts.timeout,
       ...(Object.keys(warmupOpts.environment).length

--- a/test/utils/configUtils.js
+++ b/test/utils/configUtils.js
@@ -30,7 +30,7 @@ function getExpectedFunctionConfig(options = {}) {
     handler: '_warmup/index.warmUp',
     memorySize: 128,
     name: 'warmup-test-dev-warmup-plugin',
-    runtime: 'nodejs10.x',
+    runtime: 'nodejs12.x',
     package: {
       individually: true,
       exclude: ['**'],


### PR DESCRIPTION
AWS lambda have announced support for NodeJS 12 see https://aws.amazon.com/about-aws/whats-new/2019/11/aws-lambda-supports-node-js-12/