### PR TITLE
Add Node.js 13 to CI setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "10"
   - "11"
   - "12"
+  - "13"
 script:
   - "npm run lint"
   - "npm run test-with-coverage"


### PR DESCRIPTION
Node.js13 was also added because there were settings other than LTS.
Close it if you don't need it.